### PR TITLE
added flipyz option to plugin for swapping the Y and Z axes around

### DIFF
--- a/blender-2.64/iqm_export.py
+++ b/blender-2.64/iqm_export.py
@@ -948,7 +948,8 @@ def collectMeshes(context, bones, scale, matfun, useskel = True, usecol = False,
 
                 # Quake winding is reversed
                 for i in range(2, len(faceverts)):
-                    mesh.tris.append((faceverts[0], faceverts[i], faceverts[i-1])) 
+                    mesh.tris.append((faceverts[0], faceverts[i-1], faceverts[i])) 
+                    #mesh.tris.append((faceverts[0], faceverts[i], faceverts[i-1])) 
  
     for mesh in meshes:
         mesh.optimize()


### PR DESCRIPTION
Very useful plugin, but with a quirk! Blender uses a different orientation to most game engines - the Z axis is upwards instead of Y. This is quite troublesome since all models get flipped when loading them into a game which doesn't take that into consideration. This issue would turn even more prevalent if IQM models are delivered from several different 3D animation applications of which some might not be flipped. Since it is an issue on blender's side, it seems reasonable to solve it in the exporter.

This pull request creates a new property for the plugin called "Flip Y and Z" which flips the Y and Z axes around in the exporter to circumvent the issue. I tried it with my own game and it works. However since I have only gotten to the point of displaying meshes (no animations), it is untested with animations and anything that isn't just meshes. I also only added the code to the collectMeshes function since I couldn't test if something needed to be done in the animation loading function. But if that is the case, maybe it would be easy for you to apply the same solution where needed, otherwise I could update the pull request whenever I get to loading animations. :)
