### PR TITLE
Fixed context.depsgraph API change issue.

### DIFF
--- a/blender-2.80/iqm_export.py
+++ b/blender-2.80/iqm_export.py
@@ -813,7 +813,7 @@ def collectMeshes(context, bones, scale, matfun, useskel = True, usecol = False,
     meshes = []
     for obj in objs:
         if obj.type == 'MESH':
-            data = obj.to_mesh(context.depsgraph, True)
+            data = obj.evaluated_get(context.evaluated_depsgraph_get()).to_mesh()
             if not data.polygons:
                 continue
             data.calc_normals_split()


### PR DESCRIPTION
The IQM exporter is currently broken in Blender 2.80rc1.