### PR TITLE
hashtable resizing for large models

### DIFF
--- a/iqm.cpp
+++ b/iqm.cpp
@@ -43,6 +43,11 @@ static inline bool htcmp(const char *x, const sharedstring &s)
     return htcmp(x, &stringdata[s.offset]);
 }
 
+static inline uint hthash(const sharedstring &s)
+{
+    return hthash(&stringdata[s.offset]);
+}
+
 hashtable<sharedstring, uint> stringoffsets;
 
 uint sharestring(const char *s)
@@ -3757,4 +3762,3 @@ int main(int argc, char **argv)
 
 	return EXIT_SUCCESS;
 }
-

--- a/util.h
+++ b/util.h
@@ -319,7 +319,8 @@ template <class K, class T> struct hashtable
 
     chain *insert(const K &key, uint h)
     {
-        if(size*RESIZERATIO < MAXSIZE && float(++numelems) / size * 100.0 > MAXLOADFACTOR) { rehash(); h = hthash(key)&(size-1); }
+        ++numelems;
+        if(size*RESIZERATIO < MAXSIZE && float(numelems) / size * 100.0 > MAXLOADFACTOR) { rehash(); h = hthash(key)&(size-1); }
         return insert(unused, chunks, table, key, h);
     }
 

--- a/util.h
+++ b/util.h
@@ -289,7 +289,7 @@ template <class K, class T> struct hashtable
     typedef T value;
     typedef const T const_value;
 
-    enum { CHUNKSIZE = 64 };
+    enum { CHUNKSIZE = 64, MAXLOADFACTOR = 75, RESIZERATIO = 4, MAXSIZE = 128<<20 };
 
     struct chain      { T data; K key; chain *next; };
     struct chainchunk { chain chains[CHUNKSIZE]; chainchunk *next; };
@@ -319,6 +319,12 @@ template <class K, class T> struct hashtable
 
     chain *insert(const K &key, uint h)
     {
+        if(size*RESIZERATIO < MAXSIZE && float(++numelems) / size * 100.0 > MAXLOADFACTOR) { rehash(); h = hthash(key)&(size-1); }
+        return insert(unused, chunks, table, key, h);
+    }
+
+    static chain *insert(chain *&unused, chainchunk *&chunks, chain **&table, const K& key, uint h)
+    {
         if(!unused)
         {
             chainchunk *chunk = new chainchunk;
@@ -333,7 +339,6 @@ template <class K, class T> struct hashtable
         c->key = key;
         c->next = table[h]; 
         table[h] = c;
-        numelems++;
         return c;
     }
 
@@ -409,6 +414,31 @@ template <class K, class T> struct hashtable
         numelems = 0;
         unused = NULL;
         deletechunks();
+    }
+
+    void rehash()
+    {
+        int newsize = size*RESIZERATIO;
+        chain **newtable = new chain* [newsize];
+        loopi(newsize) newtable[i] = NULL;
+
+        chainchunk *newchunks = NULL;
+        chain *newunused = NULL;
+        loopi(size) for (chain *c = table[i]; c;)
+        {
+            const K& k = c->key;
+            uint h = hthash(k)&(newsize-1);
+            insert(newunused, newchunks, newtable, k, h)->data = c->data;
+            c = c->next;
+        }
+
+        delete[] table;
+        deletechunks();
+
+        size = newsize;
+        table = newtable;
+        chunks = newchunks;
+        unused = newunused;
     }
 };
 
@@ -1077,4 +1107,3 @@ void fatal(const char *s, ...)    // failure exit
 
     exit(EXIT_FAILURE);
 }
-

--- a/util.h
+++ b/util.h
@@ -427,7 +427,7 @@ template <class K, class T> struct hashtable
         chain *newunused = NULL;
         loopi(size) for (chain *c = table[i]; c;)
         {
-            const K& k = c->key;
+            const K &k = c->key;
             uint h = hthash(k)&(newsize-1);
             insert(newunused, newchunks, newtable, k, h)->data = c->data;
             c = c->next;


### PR DESCRIPTION
The following implements a basic load factor check and resizes the hashtable when the load factor gets too large, which is controllable by `MAXLOADFACTOR` which is set at 75%. The resizing ratio is controllable by `RESIZERATIO` and the default of 4 was empirically picked on some large models. If the table gets too large, controlled by `MAXSIZE` it won't rehash to avoid OOM but rather degrade to linear time operations.