### PR TITLE
exporter: fix vert groups

### DIFF
--- a/blender-2.80/iqm_export.py
+++ b/blender-2.80/iqm_export.py
@@ -813,7 +813,8 @@ def collectMeshes(context, bones, scale, matfun, useskel = True, usecol = False,
     meshes = []
     for obj in objs:
         if obj.type == 'MESH':
-            data = obj.evaluated_get(context.evaluated_depsgraph_get()).to_mesh() if usemods else obj.original.to_mesh()
+            dg = context.evaluated_depsgraph_get()
+            data = obj.evaluated_get(dg).to_mesh(preserve_all_data_layers=True, depsgraph=dg) if usemods else obj.original.to_mesh(preserve_all_data_layers=True, depsgraph=dg)
             if not data.polygons:
                 continue
             data.calc_normals_split()


### PR DESCRIPTION
to_mesh() requires additional parameters passed in order to preserve vertex group data.