### PR TITLE
Fix action intervals when they are 0

### DIFF
--- a/blender-2.80/iqm_export.py
+++ b/blender-2.80/iqm_export.py
@@ -738,7 +738,7 @@ def collectBones(context, armature, scale):
 
 
 def collectAnim(context, armature, scale, bones, action, startframe = None, endframe = None):
-    if not startframe or not endframe:
+    if startframe is None or endframe is None:
         startframe, endframe = action.frame_range
         startframe = int(startframe)
         endframe = int(endframe)


### PR DESCRIPTION
Like the title says, if the intervals start frame or end frame are 0, the scripts detects them incorrectly. This PR fixes it.