### PR TITLE
Manual export of vertex weights without exporting skeleton data

### DIFF
--- a/blender-2.93/iqm_export.py
+++ b/blender-2.93/iqm_export.py
@@ -812,7 +812,7 @@ def collectAnims(context, armature, scale, bones, animspecs):
     return anims
 
  
-def collectMeshes(context, bones, scale, matfun, useskel = True, usecol = False, usemods = False, filetype = 'IQM'):
+def collectMeshes(context, bones, scale, matfun, useweights = True, usecol = False, usemods = False, filetype = 'IQM'):
     vertwarn = []
     objs = context.selected_objects #context.scene.objects
     meshes = []
@@ -907,7 +907,7 @@ def collectMeshes(context, bones, scale, matfun, useskel = True, usecol = False,
                             vertcol = (255, 255, 255, int(round(vertalpha[0] * 255.0)))
 
                     vertweights = []
-                    if useskel:
+                    if useweights:
                         for g in v.groups:
                             try:
                                 vertweights.append((g.weight, bones[groups[g.group].name].index))
@@ -1014,9 +1014,9 @@ def exportIQE(file, meshes, bones, anims):
     file.write('\n')
 
 
-def exportIQM(context, filename, usemesh = True, usemods = False, useskel = True, usebbox = True, usecol = False, scale = 1.0, animspecs = None, matfun = (lambda prefix, image: image), derigify = False, boneorder = None):
+def exportIQM(context, filename, usemesh = True, useweights = True, usemods = False, useskel = True, usebbox = True, usecol = False, scale = 1.0, animspecs = None, matfun = (lambda prefix, image: image), derigify = False, boneorder = None):
     armature = findArmature(context)
-    if useskel and not armature:
+    if (useskel or useweights) and not armature:
         print('No armature selected')
         return
 
@@ -1028,7 +1028,7 @@ def exportIQM(context, filename, usemesh = True, usemods = False, useskel = True
         print('Unknown file type: %s' % filename)
         return
 
-    if useskel:
+    if useskel or useweights:
         if derigify:
             bones = derigifyBones(context, armature, scale)
         else:
@@ -1058,7 +1058,7 @@ def exportIQM(context, filename, usemesh = True, usemods = False, useskel = True
 
     bonelist = sorted(bones.values(), key = lambda bone: bone.index)
     if usemesh:
-        meshes = collectMeshes(context, bones, scale, matfun, useskel, usecol, usemods, filetype)
+        meshes = collectMeshes(context, bones, scale, matfun, useweights, usecol, usemods, filetype)
     else:
         meshes = []
 
@@ -1107,6 +1107,7 @@ class ExportIQM(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
     usemods: bpy.props.BoolProperty(name="Modifiers", description="Apply modifiers", default=True)
     useskel: bpy.props.BoolProperty(name="Skeleton", description="Generate skeleton", default=True)
     usebbox: bpy.props.BoolProperty(name="Bounding boxes", description="Generate bounding boxes", default=True)
+    useweights: bpy.props.BoolProperty(name="Vertex weights", description="Export vertex weights", default=True)
     usecol: bpy.props.BoolProperty(name="Vertex colors", description="Export vertex colors", default=False)
     usescale: bpy.props.FloatProperty(name="Scale", description="Scale of exported model", default=1.0, min=0.0, step=50, precision=2)
     #usetrans: bpy.props.FloatVectorProperty(name="Translate", description="Translate position of exported model", step=50, precision=2, size=3)
@@ -1121,7 +1122,7 @@ class ExportIQM(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
             matfun = lambda prefix, image: prefix
         else:
             matfun = lambda prefix, image: image
-        exportIQM(context, self.properties.filepath, self.properties.usemesh, self.properties.usemods, self.properties.useskel, self.properties.usebbox, self.properties.usecol, self.properties.usescale, self.properties.animspec, matfun, self.properties.derigify, self.properties.boneorder)
+        exportIQM(context, self.properties.filepath, self.properties.usemesh, self.properties.useweights, self.properties.usemods, self.properties.useskel, self.properties.usebbox, self.properties.usecol, self.properties.usescale, self.properties.animspec, matfun, self.properties.derigify, self.properties.boneorder)
         return {'FINISHED'}
 
     def check(self, context):


### PR DESCRIPTION
Unless I'm misunderstanding something about the exporter, the only way you can export vertex weights is by also exporting the skeleton. This makes it difficult to create modular assets such as clothing, backpacks, or other soft worn articles, since it would require a lot more legwork on the application's part to de-duplicate the rig and associate the items with whatever pose buffer is used to store the wearer's rig state.

This modification to the export script adds an additional checkbox "Vertex weights" which allows for explicit control over whether or not vertex weights are exported. When exporting a rig this should always be checked, but it can also be checked when exporting a rigged object that will later be slaved to the skeleton in the final application, without exporting the actual rig data. This is similar to exporting one IQM file containing multiple meshes which reference the same rig, but much more modular as it allows the resulting assets to exist in separate files without duplicate data. The exported vertex bone IDs will be the same as usual, only that the bones they reference don't exist within that same file. When the mesh is loaded by the application it will be up to the application to make sure that the object is associated with the correct armature object/pose buffer, rather than creating a new one.

This is just a suggestion, I'm not sure if this change is consistent with the IQM file spec or purpose of the format. If this seems like a reasonable idea, before it gets merged it might make sense to add a warning or error to ensure "Vertex weights" is checked when exporting the rig, since exporting a rigged object without vertex weights doesn't make much sense.