### PR TITLE
Fix export error from None material entry.

### DIFF
--- a/blender-2.93/iqm_export.py
+++ b/blender-2.93/iqm_export.py
@@ -847,6 +847,9 @@ def collectMeshes(context, bones, scale, matfun, useskel = True, usecol = False,
                         colors = layer.data
             if data.materials:
                 for idx, mat in enumerate(data.materials):
+                    if not mat:
+                        continue
+
                     matprefix = mat.name or ''
                     matimage = ''
                     if mat.node_tree:


### PR DESCRIPTION
I don't know why, but this was a problem for me when trying to export some 10y old Xonotic models on Blender 3.4. Otherwise seemed to work pretty well.